### PR TITLE
Add fee estimate function to add TXins prior to fee estimate call

### DIFF
--- a/src/Transaction.js
+++ b/src/Transaction.js
@@ -51,6 +51,30 @@ class Transaction {
     }
 
     /**
+     * Create temporary TxIns and run tx.EstimateFees on the expected Tx state
+     * TxOuts must already be added for this function call
+     * Resets Tx state after running
+     * @return { Object } - Fees from Tx.estimateFees()
+     */
+    async getTxFeeEstimates(changeAddress, changeAddressCurve, UTXOIDs = []) {
+        try {
+            if (this.Tx.getTx()["Fee"] === 0) {
+                throw "No Tx fee added to tx"
+            }
+            if (this.Tx.Vout.length <= 0) {
+                throw "No Vouts for fee estimation"
+            }
+            await this._createTxIns(changeAddress, changeAddressCurve, UTXOIDs);
+            let fees = await this.Tx.estimateFees()
+            await this._reset();
+            return fees;
+        } catch (ex) {
+            this._reset();
+            throw new Error("Transaction.getTxFeeEstimates: " + String(ex));
+        }
+    }
+
+    /**
      * Create the transaction fee and account that will be paying it
      * @param {hex} payeerAddress 
      * @param {number} payeerCurve 


### PR DESCRIPTION
Adds a function to call for fee estimates that calls _createTxIns prior to running the fee estimation to provide accurate fee estimates after any ValueStores are added to balance VINs/VOUTs for change or DataStore overwrites